### PR TITLE
ci: use ubuntu-latest for faster, cheaper builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Changed test runner from `macos-latest` to `ubuntu-latest`
- Linux runners are faster and more cost-effective

🤖 Generated with [Claude Code](https://claude.com/claude-code)