### PR TITLE
feat: trigger homebrew-tap update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,11 @@ jobs:
         with:
           files: artifacts/**/*.tar.gz
           generate_release_notes: true
+
+      - name: Trigger homebrew-tap update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: karbassi/homebrew-tap
+          event-type: release
+          client-payload: '{"formula": "cc-statusline"}'


### PR DESCRIPTION
## Summary
- Adds a `repository_dispatch` step to trigger the homebrew-tap auto-update workflow when a new release is published

## How it works
1. After the release is created, this step sends a `repository_dispatch` event to `karbassi/homebrew-tap`
2. The homebrew-tap workflow receives the event and updates the formula with the new version and SHA256 hashes
3. A PR is automatically created in homebrew-tap for review

## Required Setup
Create a `HOMEBREW_TAP_TOKEN` secret in this repo with a PAT that has write access to `karbassi/homebrew-tap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)