### PR TITLE
fix: build only for Linux targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            name: cc-statusline-macos-x86_64
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            name: cc-statusline-macos-arm64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: cc-statusline-linux-x86_64
@@ -43,9 +37,11 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          fi
+          cargo build --release --target ${{ matrix.target }}
 
       - name: Package
         run: |


### PR DESCRIPTION
## Summary
- Removes macOS builds to simplify release workflow
- Fixes conditional linker env var for aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)