### PR TITLE
fix: use macos-15 for x86_64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             name: cc-statusline-macos-arm64
-          - os: macos-13
+          - os: macos-15
             target: x86_64-apple-darwin
             name: cc-statusline-macos-x86_64
           - os: ubuntu-latest


### PR DESCRIPTION
macOS-13 runners are retired.