### PR TITLE
Add pre-commit hook to block commits to main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,20 @@
 #!/bin/sh
-# Pre-commit hook: auto-format and lint
+# Pre-commit hook: block main branch, auto-format and lint
+
+# Prevent commits directly to the main branch
+branch="$(git symbolic-ref --short HEAD 2>/dev/null)"
+
+if [ "$branch" = "main" ]; then
+    echo "Error: Direct commits to 'main' are not allowed."
+    echo "Please create a feature branch and worktree:"
+    echo ""
+    echo "  git branch my-feature"
+    echo "  git worktree add .worktrees/my-feature my-feature"
+    echo "  cd .worktrees/my-feature"
+    echo "  git config core.hooksPath .githooks"
+    echo ""
+    exit 1
+fi
 
 # Capture originally staged files before formatting
 staged_files="$(git diff --cached --name-only --diff-filter=AM)"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ if [ "$branch" = "main" ]; then
     echo "  git branch my-feature"
     echo "  git worktree add .worktrees/my-feature my-feature"
     echo "  cd .worktrees/my-feature"
-    echo "  git config core.hooksPath .githooks"
+    echo "  git config core.hooksPath ../../.githooks"
     echo ""
     exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Pre-push hook: run tests before pushing
 
+# Clear git environment variables that can interfere with tests
+unset GIT_DIR GIT_WORK_TREE
+
 if ! cargo test; then
     echo "error: cargo test failed. Fix tests before pushing."
     exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-registry-
 
       - name: Build
         run: cargo build --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-02-05
+
+### Added
+
+- Pre-commit hook now blocks direct commits to main branch with worktree setup instructions
+
+### Fixed
+
+- Pre-push hook clears `GIT_DIR`/`GIT_WORK_TREE` env vars that interfered with integration tests
+
 ## [0.1.5] - 2026-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "criterion",
  "gix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-statusline"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Adds branch protection to pre-commit hook to prevent direct commits to main
- Suggests creating a feature branch and worktree when blocked
- Fixes pre-push hook to clear GIT_DIR/GIT_WORK_TREE env vars that interfere with tests

## Test plan
- [x] Verify hook blocks commits when on main branch
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)