### PR TITLE
Move config file to ~/.claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-02-18
+
+### Changed
+
+- Config file location moved from `~/.config/claude/cc-statusline.json` to `~/.claude/cc-statusline.json`
+- Removed `XDG_CONFIG_HOME` support (config now always lives alongside Claude Code's own config)
+
 ## [0.1.6] - 2026-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "criterion",
  "gix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-statusline"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Restart Claude Code to see the new status line.
 
 ## Design
 
-4-5 row status line with Tokyo Night colors and dot (•) dividers. PR row appears when a PR exists for the current branch.
+4 row status line with Tokyo Night colors and dot (•) dividers. PR row appears when a PR exists for the current branch. Layout is configurable via `~/.claude/cc-statusline.json`.
 
 See all screenshot variations in [docs/screenshots/](docs/screenshots/).
 
@@ -53,15 +53,11 @@ See all screenshot variations in [docs/screenshots/](docs/screenshots/).
 
 If no authentication is available, the PR row will not appear. On Windows, use an environment variable or git credential helper since `gh auth login` is not used by the native HTTP path.
 
-### Row 4: Claude
+### Row 4: Claude + Session
 - Model (Opus/Sonnet/Haiku)
 - Context % remaining
 - Output mode
-- Block timer
-
-### Row 5: Session
 - Session duration
-- Block reset countdown
 - Tokens (in/out)
 
 ## Style
@@ -133,7 +129,7 @@ When `git` or `pr` fields are provided in JSON, filesystem detection is skipped 
 | `GITHUB_TOKEN` | GitHub API token for PR info (preferred) |
 | `GH_TOKEN` | Alternative GitHub token (used by gh CLI) |
 | `XDG_CACHE_HOME` | Cache directory base (default: `~/.cache`) |
-| `HOME` | User home directory for `~` expansion |
+| `HOME` | User home directory for `~` expansion and config file location |
 
 Cache files are stored in `$XDG_CACHE_HOME/cc-statusline/` (or `~/.cache/cc-statusline/`).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,20 +73,16 @@ fn default_config() -> Config {
 }
 
 /// Get path to config file
-/// Uses $XDG_CONFIG_HOME/claude/cc-statusline.json or ~/.config/claude/cc-statusline.json
+/// Uses ~/.claude/cc-statusline.json
 fn get_config_path() -> PathBuf {
-    let base = env::var("XDG_CONFIG_HOME").map_or_else(
-        |_| {
-            let home = get_home();
-            if home.is_empty() {
-                PathBuf::from(".config")
-            } else {
-                PathBuf::from(home).join(".config")
-            }
-        },
-        PathBuf::from,
-    );
-    base.join("claude").join("cc-statusline.json")
+    let home = get_home();
+    if home.is_empty() {
+        PathBuf::from(".claude").join("cc-statusline.json")
+    } else {
+        PathBuf::from(home)
+            .join(".claude")
+            .join("cc-statusline.json")
+    }
 }
 
 /// Load configuration from file, returning default if missing or invalid


### PR DESCRIPTION
## Summary
- Move config file from `~/.config/claude/cc-statusline.json` to `~/.claude/cc-statusline.json`
- Remove `XDG_CONFIG_HOME` support — config now lives alongside Claude Code's own config
- Bump version to 0.1.7

## Test plan
- [x] All 79 tests pass
- [x] Config file works from `~/.claude/` on all three machines

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>