### PR TITLE
fix: count changed files by content, not mtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Changed-files count no longer reports false positives. It was comparing only each tracked file's mtime against the index, so a file that was touched but not edited (checkout, formatter re-save, `git pull`, symlink target drift) was counted as changed even though `git status` considered the repo clean. It now uses gitoxide's content-aware status (same racy-clean handling as git), so mtime-only drift is ignored.
+
 ## [0.1.8] - 2026-06-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +313,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "errno"
@@ -356,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,33 +427,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048b8d1ae2104f045cb37e5c450fc49d5d8af22609386bfc739c11ba88995eb"
 dependencies = [
  "gix-actor",
+ "gix-attributes",
+ "gix-command",
  "gix-commitgraph",
  "gix-config",
  "gix-date",
  "gix-diff",
+ "gix-dir",
  "gix-discover",
  "gix-features",
+ "gix-filter",
  "gix-fs",
  "gix-glob",
  "gix-hash",
  "gix-hashtable",
+ "gix-ignore",
  "gix-index",
  "gix-lock",
  "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-path",
+ "gix-pathspec",
  "gix-ref",
  "gix-refspec",
  "gix-revision",
  "gix-revwalk",
  "gix-sec",
+ "gix-status",
+ "gix-submodule",
  "gix-tempfile",
  "gix-trace",
  "gix-traverse",
  "gix-url",
  "gix-utils",
  "gix-validate 0.9.4",
+ "gix-worktree",
  "once_cell",
  "smallvec",
  "thiserror 1.0.69",
@@ -445,6 +483,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-attributes"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 1.0.69",
+ "unicode-bom",
+]
+
+[[package]]
 name = "gix-bitmap"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +515,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7d6b8f3a64453fd7e8191eb80b351eb7ac0839b40a1237cd2c137d5079fe53"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-trace",
+ "shell-words",
 ]
 
 [[package]]
@@ -529,8 +596,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c9afd80fff00f8b38b1c1928442feb4cd6d2232a6ed806b6b193151a3d336c"
 dependencies = [
  "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
  "gix-hash",
  "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "imara-diff",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed3a9076661359a1c5a27c12ad6c3ebe2dd96b8b3c0af6488ab7c128b7bdd98"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
  "thiserror 1.0.69",
 ]
 
@@ -567,6 +662,27 @@ dependencies = [
  "sha1_smol",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4121790ae140066e5b953becc72e7496278138d19239be2e63b5067b0843119e"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline-blocking",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -609,8 +725,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
  "gix-hash",
- "hashbrown",
+ "hashbrown 0.14.5",
  "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
 ]
 
 [[package]]
@@ -632,7 +761,7 @@ dependencies = [
  "gix-traverse",
  "gix-utils",
  "gix-validate 0.9.4",
- "hashbrown",
+ "hashbrown 0.14.5",
  "itoa",
  "libc",
  "memmap2",
@@ -710,6 +839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-packetline-blocking"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9802304baa798dd6f5ff8008a2b6516d54b74a69ca2d3a2b9e2d6c3b5556b40"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "gix-path"
 version = "0.10.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +860,21 @@ dependencies = [
  "gix-trace",
  "gix-validate 0.10.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d23bf239532b4414d0e63b8ab3a65481881f7237ed9647bb10c1e3cc54c5ceb"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -811,11 +967,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-status"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70d35ba639f0c16a6e4cca81aa374a05f07b23fa36ee8beb72c100d98b4ffea"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529d0af78cc2f372b3218f15eb1e3d1635a21c8937c12e2dd0b6fc80c2ca874b"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "gix-tempfile"
 version = "14.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa"
 dependencies = [
+ "dashmap",
  "gix-fs",
  "libc",
  "once_cell",
@@ -866,6 +1061,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff08f24e03ac8916c478c8419d7d3c33393da9bb41fa4c24455d5406aeefd35f"
 dependencies = [
+ "bstr",
  "fastrand",
  "unicode-normalization",
 ]
@@ -891,6 +1087,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-worktree"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c312ad76a3f2ba8e865b360d5cb3aa04660971d16dec6dd0ce717938d903149a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate 0.9.4",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1124,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1029,6 +1253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1336,15 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -1575,6 +1817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1845,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-gix = { version = "0.66", default-features = false, features = ["index", "revision"] }
+gix = { version = "0.66", default-features = false, features = ["revision", "status"] }
 memmap2 = "0.9"
 libc = "0.2"
 ureq = { version = "2.12", default-features = false, features = ["native-tls"] }

--- a/src/git.rs
+++ b/src/git.rs
@@ -108,7 +108,8 @@ impl GitRepo {
             })
             .into_index_worktree_iter(Vec::new())
             .ok()?
-            .filter_map(Result::ok)
+            // Count every yielded item, including per-path `Err`s: for a status line an
+            // errored/unreadable path is "unknown, treat as dirty", never silently dropped.
             .count() as u32;
 
         Some((files, 0, 0))

--- a/src/git.rs
+++ b/src/git.rs
@@ -88,35 +88,29 @@ pub(crate) struct GitRepo {
 }
 
 impl GitRepo {
-    /// Compute diff stats using git index - simplified, just count modified files
+    /// Count tracked files that differ between the index and the working tree.
+    ///
+    /// Uses gix's content-aware status (the same racy-clean handling git does), so a
+    /// file whose mtime drifted but whose content is unchanged is NOT counted — the
+    /// old mtime-only heuristic reported those as false positives. Untracked files are
+    /// excluded (dirwalk disabled), matching the previous index-only semantics; like
+    /// git's own dirty check this compares worktree-vs-index, not index-vs-HEAD, so
+    /// staged-only changes aren't counted. Line counts aren't computed.
     fn diff_stats(&self) -> Option<(u32, u32, u32)> {
-        let index = self.repo.index().ok()?;
-        let workdir = self.repo.work_dir()?;
-        let mut files = 0u32;
+        let files = self
+            .repo
+            .status(gix::progress::Discard)
+            .ok()?
+            .index_worktree_rewrites(None)
+            .index_worktree_submodules(gix::status::Submodule::AsConfigured { check_dirty: true })
+            .index_worktree_options_mut(|opts| {
+                opts.dirwalk_options = None;
+            })
+            .into_index_worktree_iter(Vec::new())
+            .ok()?
+            .filter_map(Result::ok)
+            .count() as u32;
 
-        for entry in index.entries() {
-            let path_bstr = entry.path(&index);
-            let path_str = std::str::from_utf8(path_bstr.as_ref()).ok()?;
-            let file_path = workdir.join(path_str);
-
-            if let Ok(metadata) = fs::metadata(&file_path) {
-                let mtime = metadata
-                    .modified()
-                    .ok()?
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .ok()?
-                    .as_secs();
-                let index_mtime = u64::from(entry.stat.mtime.secs);
-
-                if mtime != index_mtime {
-                    files += 1;
-                }
-            } else {
-                files += 1; // File deleted
-            }
-        }
-
-        // gix doesn't easily give line counts, so just return file count
         Some((files, 0, 0))
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -199,12 +199,20 @@ fn mtime_bump_without_content_change_is_clean() {
     let (_temp_dir, repo_path) = create_git_repo();
     make_commit(&repo_path, "initial commit");
 
-    // Bump mtime into the past without touching content.
+    // Bump mtime into the past without touching content. Assert touch actually
+    // succeeded, otherwise the test could pass vacuously (mtime never drifted).
     let file_path = repo_path.join("file-initial-commit.txt");
-    Command::new("touch")
-        .args(["-t", "202001010000", file_path.to_str().unwrap()])
+    let touch = Command::new("touch")
+        .arg("-t")
+        .arg("202001010000")
+        .arg(&file_path)
         .output()
-        .expect("failed to touch file");
+        .expect("failed to run touch");
+    assert!(
+        touch.status.success(),
+        "touch failed to set mtime: {}",
+        String::from_utf8_lossy(&touch.stderr)
+    );
 
     let stdout = run_with_json(&repo_path, "{}");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -191,6 +191,30 @@ fn detect_changed_files() {
     );
 }
 
+/// Regression: a tracked file whose mtime changed but whose content did not must
+/// NOT be counted as changed. The old mtime-only heuristic reported these as false
+/// positives (a clean repo showing "N files"); content-aware status ignores them.
+#[test]
+fn mtime_bump_without_content_change_is_clean() {
+    let (_temp_dir, repo_path) = create_git_repo();
+    make_commit(&repo_path, "initial commit");
+
+    // Bump mtime into the past without touching content.
+    let file_path = repo_path.join("file-initial-commit.txt");
+    Command::new("touch")
+        .args(["-t", "202001010000", file_path.to_str().unwrap()])
+        .output()
+        .expect("failed to touch file");
+
+    let stdout = run_with_json(&repo_path, "{}");
+
+    assert!(
+        !stdout.contains("file"),
+        "Clean repo (mtime-only drift) must not report changed files: {}",
+        stdout
+    );
+}
+
 // =============================================================================
 // JSON Input Tests
 // =============================================================================

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -194,6 +194,9 @@ fn detect_changed_files() {
 /// Regression: a tracked file whose mtime changed but whose content did not must
 /// NOT be counted as changed. The old mtime-only heuristic reported these as false
 /// positives (a clean repo showing "N files"); content-aware status ignores them.
+///
+/// Unix-only: it drives mtime drift via `touch -t`, which isn't available on Windows.
+#[cfg(unix)]
 #[test]
 fn mtime_bump_without_content_change_is_clean() {
     let (_temp_dir, repo_path) = create_git_repo();


### PR DESCRIPTION
## Problem

A clean repo showed a phantom changed-files count in the status line (e.g. `main • 18 files` while `git status` reported nothing to commit).

`GitRepo::diff_stats` compared only each tracked file's **mtime** against the index and counted any mismatch as a change. It never compared content, so files that were *touched but not edited* — `git checkout`, a formatter re-saving with identical bytes, `git pull`, or symlink-target mtime drift — were counted as changed even though git considered them clean. The mmap cache then pinned that stale count until `.git/index` changed.

## Fix

Replace the hand-rolled mtime loop with gitoxide's content-aware status (`repo.status(...).into_index_worktree_iter(...)`), which does the same racy-clean content comparison git does. Dirwalk is disabled, preserving the previous tracked-only (no untracked) semantics, and it's faster than stat-ing every index entry by hand.

- Enables the `gix` `status` feature (pulls in `dirwalk`/`index`/`blob-diff`); drops the now-redundant `index` feature.
- Adds regression test `mtime_bump_without_content_change_is_clean`.

## Verification

In a temp repo: clean → 0, mtime bump only → 0 (was the bug), content edit → 1, revert → 0. `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` (26 integration tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)