### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.9] - 2026-07-01
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.9] - 2026-07-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "cc-statusline"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "criterion",
  "gix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-statusline"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Release v0.1.9.

### Fixed
- Changed-files count no longer reports false positives — switched from an mtime-only heuristic to gitoxide's content-aware status ([#32](https://github.com/karbassi/cc-status-line/pull/32)).

Version bump + CHANGELOG only. Tagging `v0.1.9` after merge triggers the release build + homebrew-tap update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)